### PR TITLE
fix: check if plist exists

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -66,8 +66,10 @@ function darwin_install(cfg) {
 
 function darwin_uninstall(cfg) {
     var plist_file = `/Library/LaunchDaemons/${cfg.name}.plist`;
-    child_process.run("launchctl", ["unload", plist_file]);
-    fs.unlink(plist_file);
+    if(fs.exists(plist_file)){
+        child_process.run("launchctl", ["unload", plist_file]);
+        fs.unlink(plist_file);
+    }
 }
 
 exports.install = function (cfg) {


### PR DESCRIPTION
Check whether the plist file exists before deleting it.